### PR TITLE
fix: absolute $HOME path, remove gnupg private symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::shell::aliases::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::shell::deps()`
 - `p6df::modules::shell::external:::home::symlink()`
 - `p6df::modules::shell::external::brew()`
@@ -48,7 +48,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::shell::vscodes::config()`
 - `stream  = p6_shell_tcp_is(port)`
   - Args:
-    - port - 
+    - port -
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -22,8 +22,7 @@ p6df::modules::shell::deps() {
 ######################################################################
 p6df::modules::shell::external:::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_DIR/$USER/home-private/gnupg" ".gnupg"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-shell/share/.parallel"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-shell/share/.parallel" "$HOME/.parallel"
 
   p6_return_void
 }


### PR DESCRIPTION
Fix .parallel symlink to use absolute $HOME. Remove the gnupg symlink that pointed to a user-private directory.