### PR TITLE
chore(shell): rename home::symlink to home::symlinks, add aspell files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-share/
+share/.parallel/runs-without-willing-to-cite

--- a/init.zsh
+++ b/init.zsh
@@ -15,14 +15,16 @@ p6df::modules::shell::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::shell::external:::home::symlink()
+# Function: p6df::modules::shell::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR USER
 #>
 ######################################################################
-p6df::modules::shell::external:::home::symlink() {
+p6df::modules::shell::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-shell/share/.parallel" "$HOME/.parallel"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-shell/share/.aspell.en.pws" "$HOME/.aspell.en.pws"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-shell/share/.aspell.en.prepl" "$HOME/.aspell.en.prepl"
 
   p6_return_void
 }

--- a/share/.aspell.en.prepl
+++ b/share/.aspell.en.prepl
@@ -1,0 +1,3 @@
+personal_repl-1.1 en 0 
+duing during
+personalization personalizing

--- a/share/.aspell.en.prepl
+++ b/share/.aspell.en.prepl
@@ -1,3 +1,3 @@
-personal_repl-1.1 en 0 
+personal_repl-1.1 en 2
 duing during
 personalization personalizing

--- a/share/.aspell.en.pws
+++ b/share/.aspell.en.pws
@@ -1,0 +1,4 @@
+personal_ws-1.1 en 3 
+Jupyter
+PIA
+readme


### PR DESCRIPTION
## What
Rename \`home::symlink\` (singular) to \`home::symlinks\` (plural) so the framework auto-discovers and calls it. Fix \`external:::\` namespace typo. Add aspell wordlist and replacement files to share/ and symlink function. Tighten .gitignore.

## Why
The p6df-core framework dispatches \`home::symlinks\` (plural) via \`p6df::core::internal::recurse\`. The old singular function name was never auto-called — symlinks only existed from prior manual creation. The \`share/\` gitignore was hiding all share content from tracking.

## Test plan
- \`p6df home symlinks\` recreates ~/.parallel, ~/.aspell.en.pws, ~/.aspell.en.prepl without manual intervention
- \`git status\` shows .aspell files tracked, runs-without-willing-to-cite ignored

## Dependencies
None