### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,24 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::shell::deps()
+#
+#>
+######################################################################
 p6df::modules::shell::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::path::init()
+#
+#  Environment:	 HOMEBREW_PREFIX
+#>
 ######################################################################
 p6df::modules::shell::path::init() {
 
@@ -17,6 +30,17 @@ p6df::modules::shell::path::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::aliases::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#  Environment:	 LSCOLORS OSTYPE TERM USER
+#>
 ######################################################################
 p6df::modules::shell::aliases::init() {
   local _module="$1"
@@ -66,6 +90,13 @@ p6df::modules::shell::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::shell::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::shell::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-shell/share/.parallel" "$HOME/.parallel"
@@ -75,6 +106,12 @@ p6df::modules::shell::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::shell::external::brews() {
 
@@ -142,6 +179,12 @@ p6df::modules::shell::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::shell::vscodes()
+#
+#>
+######################################################################
 p6df::modules::shell::vscodes() {
 
   # shell
@@ -153,6 +196,12 @@ p6df::modules::shell::vscodes() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::shell::vscodes::config() {
 
@@ -171,55 +220,6 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::aliases::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#  Environment:	 LSCOLORS OSTYPE TERM USER
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::path::init()
-#
-#  Environment:	 HOMEBREW_PREFIX
-#>
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::shell::deps()
-#
-#>
-######################################################################
 p6df::modules::shell::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -13,12 +7,64 @@ p6df::modules::shell::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::shell::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
+p6df::modules::shell::path::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  p6_path_if "$HOMEBREW_PREFIX/opt/lsof/bin" "prepend"
+  p6_path_if "$HOMEBREW_PREFIX/opt/curl/bin" "prepend"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::shell::aliases::init() {
+  local _module="$1"
+  local dir="$2"
+
+  p6_alias "_" "sudo"
+  p6_alias "rmrf" "rm -rf"
+  p6_alias "cpr" "cp -R"
+  p6_alias "mvf" "mv -f"
+  p6_alias "bclq" "bc -lq"
+  p6_alias "grepr" "grep -R"
+
+  p6_alias "j" "jobs -l"
+  p6_alias "h" "history 25"
+  p6_alias "duh" "du -h"
+  p6_alias "history" "fc -l 1"
+
+  p6_alias "256color" "export TERM=xterm-256color"
+  p6_alias "prettyjson" "python -mjson.tool"
+
+  p6_alias "myip" "dig +short myip.opendns.com @resolver1.opendns.com"
+
+  p6_alias "whichlinux" "uname -a; cat /etc/*release; cat /etc/issue"
+
+  p6_alias "netstat" "netstat -an -p tcp"
+  p6_alias "listen" "netstat -an -p tcp | p6_filter_row_select LISTEN"
+  p6_alias "listenu" "netstat -an -p udp"
+  p6_alias "established" "netstat -an -p tcp | p6_filter_row_select ESTABLISHED"
+
+  p6_alias "tarx" "tar -xvzof"
+  p6_alias "tart" "tar -tvzf"
+
+  alias -g me='| p6_filter_row_select $USER'
+  alias -g ng='| p6_filter_row_exclude_regex "\.git"'
+
+  p6_alias "xclean" "p6_xclean"
+
+  p6_env_export LSCOLORS "Gxfxcxdxbxegedabagacad"
+  case "$OSTYPE" in
+  freebsd* | darwin*) p6_alias "ll" "ls -alFGTh" ;;
+  *) p6_alias "ll" "/bin/ls -alFh --color=auto" ;;
+  esac
+
+  p6_alias "ssh_key_check" "p6_ssh_key_check"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::shell::home::symlinks() {
 
@@ -29,54 +75,6 @@ p6df::modules::shell::home::symlinks() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::vscodes()
-#
-#>
-######################################################################
-p6df::modules::shell::vscodes() {
-
-  # shell
-  p6df::modules::vscode::extension::install foxundermoon.shell-format
-  p6df::modules::vscode::extension::install timonwong.shellcheck
-  p6df::modules::vscode::extension::install jetmartin.bats
-  p6df::modules::vscode::extension::install ms-vscode-remote.remote-ssh
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::vscodes::config()
-#
-#>
-######################################################################
-p6df::modules::shell::vscodes::config() {
-
-  cat <<'EOF'
-  "[shellscript]": {
-    "editor.defaultFormatter": "foxundermoon.shell-format"
-  },
-  "editor.codeActionsOnSave": {
-    "source.fixAll.shellcheck": "explicit"
-  },
-  "shellcheck.customArgs": ["-x", "--severity=error"],
-  "shellcheck.run": "onSave",
-  "shellformat.flag": "-i 2 -ci -sr"
-EOF
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::shell::external::brews()
-#
-#>
 ######################################################################
 p6df::modules::shell::external::brews() {
 
@@ -144,6 +142,67 @@ p6df::modules::shell::external::brews() {
 }
 
 ######################################################################
+p6df::modules::shell::vscodes() {
+
+  # shell
+  p6df::modules::vscode::extension::install foxundermoon.shell-format
+  p6df::modules::vscode::extension::install timonwong.shellcheck
+  p6df::modules::vscode::extension::install jetmartin.bats
+  p6df::modules::vscode::extension::install ms-vscode-remote.remote-ssh
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::shell::vscodes::config() {
+
+  cat <<'EOF'
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.shellcheck": "explicit"
+  },
+  "shellcheck.customArgs": ["-x", "--severity=error"],
+  "shellcheck.run": "onSave",
+  "shellformat.flag": "-i 2 -ci -sr"
+EOF
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::vscodes::config()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::shell::external::brews()
+#
+#>
+######################################################################
 #<
 #
 # Function: p6df::modules::shell::aliases::init(_module, dir)
@@ -155,71 +214,12 @@ p6df::modules::shell::external::brews() {
 #  Environment:	 LSCOLORS OSTYPE TERM USER
 #>
 ######################################################################
-p6df::modules::shell::aliases::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_alias "_" "sudo"
-  p6_alias "rmrf" "rm -rf"
-  p6_alias "cpr" "cp -R"
-  p6_alias "mvf" "mv -f"
-  p6_alias "bclq" "bc -lq"
-  p6_alias "grepr" "grep -R"
-
-  p6_alias "j" "jobs -l"
-  p6_alias "h" "history 25"
-  p6_alias "duh" "du -h"
-  p6_alias "history" "fc -l 1"
-
-  p6_alias "256color" "export TERM=xterm-256color"
-  p6_alias "prettyjson" "python -mjson.tool"
-
-  p6_alias "myip" "dig +short myip.opendns.com @resolver1.opendns.com"
-
-  p6_alias "whichlinux" "uname -a; cat /etc/*release; cat /etc/issue"
-
-  p6_alias "netstat" "netstat -an -p tcp"
-  p6_alias "listen" "netstat -an -p tcp | p6_filter_row_select LISTEN"
-  p6_alias "listenu" "netstat -an -p udp"
-  p6_alias "established" "netstat -an -p tcp | p6_filter_row_select ESTABLISHED"
-
-  p6_alias "tarx" "tar -xvzof"
-  p6_alias "tart" "tar -tvzf"
-
-  alias -g me='| p6_filter_row_select $USER'
-  alias -g ng='| p6_filter_row_exclude_regex "\.git"'
-
-  p6_alias "xclean" "p6_xclean"
-
-  p6_env_export LSCOLORS "Gxfxcxdxbxegedabagacad"
-  case "$OSTYPE" in
-  freebsd* | darwin*) p6_alias "ll" "ls -alFGTh" ;;
-  *) p6_alias "ll" "/bin/ls -alFh --color=auto" ;;
-  esac
-
-  p6_alias "ssh_key_check" "p6_ssh_key_check"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::shell::path::init()
 #
 #  Environment:	 HOMEBREW_PREFIX
 #>
-######################################################################
-p6df::modules::shell::path::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  p6_path_if "$HOMEBREW_PREFIX/opt/lsof/bin" "prepend"
-  p6_path_if "$HOMEBREW_PREFIX/opt/curl/bin" "prepend"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None