### PR TITLE
feat(shell): add tcp lib helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
 - [Usage](#usage)
+  - [Aliases](#aliases)
   - [Functions](#functions)
 - [Hierarchy](#hierarchy)
 - [Author](#author)
@@ -29,6 +30,32 @@ TODO: Add a short summary of this module.
 
 ## Usage
 
+### Aliases
+
+- `256color` -> `export TERM=xterm-256color`
+- `_` -> ``
+- `bclq` -> `bc -lq`
+- `cpr` -> `cp -R`
+- `duh` -> `du -h`
+- `established` -> `netstat -an -p tcp | p6_filter_row_select ESTABLISHED`
+- `grepr` -> `grep -R`
+- `h` -> `history 25`
+- `history` -> `fc -l 1`
+- `j` -> `jobs -l`
+- `listen` -> `netstat -an -p tcp | p6_filter_row_select LISTEN`
+- `listenu` -> `netstat -an -p udp`
+- `ll` -> `/bin/ls -alFh --color=auto`
+- `mvf` -> `mv -f`
+- `myip` -> `dig +short myip.opendns.com @resolver1.opendns.com`
+- `netstat` -> `netstat -an -p tcp`
+- `prettyjson` -> `python -mjson.tool`
+- `rmrf` -> `rm -rf`
+- `ssh_key_check` -> `p6_ssh_key_check`
+- `tart` -> `tar -tvzf`
+- `tarx` -> `tar -xvzof`
+- `whichlinux` -> `uname -a; cat /etc/*release; cat /etc/issue`
+- `xclean` -> `p6_xclean`
+
 ### Functions
 
 #### p6df-shell
@@ -37,28 +64,37 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::shell::aliases::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
 - `p6df::modules::shell::deps()`
-- `p6df::modules::shell::external:::home::symlink()`
-- `p6df::modules::shell::external::brew()`
-- `p6df::modules::shell::external::yum()`
-- `p6df::modules::shell::path::init()`
+- `p6df::modules::shell::external::brews()`
+- `p6df::modules::shell::home::symlinks()`
+- `p6df::modules::shell::path::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
 - `p6df::modules::shell::vscodes()`
 - `p6df::modules::shell::vscodes::config()`
+
+#### p6df-shell/lib
+
+##### p6df-shell/lib/tcp.zsh
+
 - `stream  = p6_shell_tcp_is(port)`
   - Args:
-    - port -
+    - port
 
 ## Hierarchy
 
 ```text
 .
 ├── init.zsh
+├── lib
+│   └── tcp.zsh
 ├── README.md
 └── share
 
-2 directories, 2 files
+3 directories, 3 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -15,7 +15,11 @@ p6df::modules::shell::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::shell::path::init()
+# Function: p6df::modules::shell::path::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 HOMEBREW_PREFIX
 #>
@@ -220,23 +224,3 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: stream  = p6_shell_tcp_is(port)
-#
-#  Args:
-#	port -
-#
-#  Returns:
-#	stream - 
-#
-#>
-######################################################################
-p6_shell_tcp_is() {
-  local port="$1"
-
-  lsof -iTCP:"$port" -sTCP:LISTEN -n -P
-
-  p6_return_stream
-}

--- a/lib/tcp.zsh
+++ b/lib/tcp.zsh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: stream  = p6_shell_tcp_is(port)
+#
+#  Args:
+#	port -
+#
+#  Returns:
+#	stream - 
+#
+#>
+######################################################################
+p6_shell_tcp_is() {
+  local port="$1"
+
+  lsof -iTCP:"$port" -sTCP:LISTEN -n -P
+
+  p6_return_stream
+}


### PR DESCRIPTION
**What:** Add `lib/tcp.zsh` helper and update `init.zsh` to source it.

**Why:** Extracts TCP/network helpers into a dedicated lib module for better organization and reuse.

**Test plan:** Source the module in a zsh session and verify TCP functions are available.

**Dependencies:** none